### PR TITLE
Adjust _legacyConstructor for Infura API

### DIFF
--- a/providers/provider.js
+++ b/providers/provider.js
@@ -493,7 +493,7 @@ utils.defineProperty(Provider, '_legacyConstructor', function(network, length, a
         // Overriding chain ID
         if (length === 2 && chainId != null) {
             network = {
-                chainId: chainId,
+                chainId: typeof(chainId) == 'number' ? chainId : testnet ? 2: 1,
                 ensAddress: network.ensAddress,
                 name: network.name
             };


### PR DESCRIPTION
After running a few tests with the new provider.Infura method it seems the apiAccessToken is being passed to the legacy constructor, instead of the chainId.

From what I can tell the simplest strategy (as of right now in the legacy constructor) is fallback to ```testnet``` var to correctly override the network settings.

```
chainId: typeof(chainId) == 'number' ? chainId : testnet ? 2: 1,
```

I have tested, but this should catch the EtherScan custom token too?